### PR TITLE
重複入力時の勾配蓄積バグ修正

### DIFF
--- a/add.py
+++ b/add.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+
+from function import Function
+from variable import Variable
+
+
+class Add(Function):
+    def forward(self, *xs: np.ndarray) -> np.ndarray:
+        if not xs:
+            raise ValueError('Add function requires at least one input.')
+
+        total = xs[0]
+        for x in xs[1:]:
+            total = total + x
+        return total
+
+    def backward(self, gy: np.ndarray) -> tuple[np.ndarray, ...]:
+        if not hasattr(self, 'inputs'):
+            raise ValueError('Inputs are not set for this function.')
+        return tuple(gy for _ in range(len(self.inputs)))
+
+
+def add(*inputs: Variable | Sequence[Variable]) -> Variable:
+    if len(inputs) == 1 and isinstance(inputs[0], Sequence):
+        sequence_inputs = inputs[0]
+        return Add()(*sequence_inputs)
+    return Add()(*inputs)  # type: ignore[arg-type]

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -1,0 +1,40 @@
+import os
+import sys
+import unittest
+
+import numpy as np
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from add import add
+from variable import Variable
+
+
+class AddTest(unittest.TestCase):
+    def test_forward_with_multiple_inputs(self):
+        x1 = Variable(np.array(1.0))
+        x2 = Variable(np.array(2.0))
+        x3 = Variable(np.array(3.0))
+        y = add(x1, x2, x3)
+        expected = np.array(6.0)
+        self.assertTrue(np.allclose(y.data, expected))
+
+    def test_backward_accumulates_gradient_for_duplicate_inputs(self):
+        x = Variable(np.array(1.0))
+        y = add(x, x, x)
+        y.backward()
+        expected = np.array(3.0)
+        self.assertTrue(np.allclose(x.grad, expected))
+
+    def test_forward_with_sequence_input(self):
+        x1 = Variable(np.array([1.0, 2.0]))
+        x2 = Variable(np.array([3.0, 4.0]))
+        y = add([x1, x2])
+        expected = np.array([4.0, 6.0])
+        self.assertTrue(np.allclose(y.data, expected))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/variable.py
+++ b/variable.py
@@ -48,6 +48,9 @@ class Variable:
                 raise ValueError('Function inputs are missing.')
 
             for x, gx in zip(inputs, gxs):
-                x.grad = gx
+                if x.grad is None:
+                    x.grad = gx
+                else:
+                    x.grad = x.grad + gx
                 if x.creator is not None:
                     funcs.append(x.creator)


### PR DESCRIPTION
## 概要
- Variable.backwardで既存の勾配に加算するよう修正し、重複入力時でも正しく蓄積されるようにしました
- Add関数で同じ変数を複数回入力した際に勾配が3になることを確認するテストを追加しました

## テスト
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68e5a7296694832b91702e2a58ac79ca