### PR TITLE
weakrefによる循環参照の解消

### DIFF
--- a/function.py
+++ b/function.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any, List, Sequence, Tuple, Union
 
+import weakref
+
 import numpy as np
 
 from variable import Variable
@@ -35,7 +37,7 @@ class Function:
             output.set_creator(self)
 
         self.inputs = list(inputs)
-        self.outputs = outputs
+        self.outputs = [weakref.ref(output) for output in outputs]
         return outputs[0] if len(outputs) == 1 else outputs
 
     def forward(self, *xs: np.ndarray) -> Tuple[np.ndarray, ...] | np.ndarray:

--- a/variable.py
+++ b/variable.py
@@ -38,9 +38,13 @@ class Variable:
 
         while funcs:
             f = funcs.pop()
-            outputs = getattr(f, 'outputs', None)
-            if outputs is None:
+            output_refs = getattr(f, 'outputs', None)
+            if output_refs is None:
                 raise ValueError('Function outputs are missing.')
+
+            outputs = [output_ref() for output_ref in output_refs]
+            if any(output is None for output in outputs):
+                raise ValueError('Function output has been deallocated.')
 
             gys = [output.grad for output in outputs]
             if any(gy is None for gy in gys):


### PR DESCRIPTION
## 概要
- Functionが保持する出力変数をweakrefで管理し、Variableとの循環参照を防止
- backward処理でweakref経由の出力取得と検証を追加

## テスト
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e853423e24832bb890fdeb029d8f0e