### PR TITLE
Mulクラスの実装と演算子オーバーロードの追加

### DIFF
--- a/add.py
+++ b/add.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Sequence
+from typing import Any, Sequence
 
 import numpy as np
 
@@ -24,8 +24,20 @@ class Add(Function):
         return tuple(gy for _ in range(len(self.inputs)))
 
 
-def add(*inputs: Variable | Sequence[Variable]) -> Variable:
+def add(*inputs: Any) -> Variable:
+    if len(inputs) == 0:
+        raise ValueError('Add function requires at least one input.')
+
     if len(inputs) == 1 and isinstance(inputs[0], Sequence):
         sequence_inputs = inputs[0]
-        return Add()(*sequence_inputs)
-    return Add()(*inputs)  # type: ignore[arg-type]
+        variables = [Variable._ensure_variable(value) for value in sequence_inputs]
+    else:
+        variables = [Variable._ensure_variable(value) for value in inputs]
+
+    if not variables:
+        raise ValueError('Add function requires at least one input.')
+
+    return Add()(*variables)  # type: ignore[arg-type]
+
+
+Variable.__add__ = add  # type: ignore[assignment]

--- a/mul.py
+++ b/mul.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from function import Function
+from variable import Variable
+
+
+class Mul(Function):
+    def forward(self, x0: np.ndarray, x1: np.ndarray) -> np.ndarray:
+        return x0 * x1
+
+    def backward(self, gy: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        if not hasattr(self, 'inputs') or len(self.inputs) != 2:
+            raise ValueError('Mul function requires exactly two inputs.')
+
+        x0, x1 = self.inputs
+        if x0.data is None or x1.data is None:
+            raise ValueError('Input data must not be None.')
+
+        gx0 = gy * x1.data
+        gx1 = gy * x0.data
+        return gx0, gx1
+
+
+def mul(x0: Any, x1: Any) -> Variable:
+    x0_var = Variable._ensure_variable(x0)
+    x1_var = Variable._ensure_variable(x1)
+    return Mul()(x0_var, x1_var)
+
+
+Variable.__mul__ = mul  # type: ignore[assignment]

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -49,6 +49,13 @@ class AddTest(unittest.TestCase):
         self.assertTrue(np.allclose(y2.data, np.array(3.0)))
         self.assertTrue(np.allclose(x.grad, np.array(3.0)))
 
+    def test_operator_overload_with_scalar(self):
+        x = Variable(np.array(2.0))
+        y = x + 3
+        y.backward()
+        self.assertTrue(np.allclose(y.data, np.array(5.0)))
+        self.assertTrue(np.allclose(x.grad, np.array(1.0)))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_mul.py
+++ b/tests/test_mul.py
@@ -1,0 +1,39 @@
+import os
+import sys
+import unittest
+
+import numpy as np
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from mul import mul
+from variable import Variable
+
+
+class MulTest(unittest.TestCase):
+    def test_forward(self):
+        x1 = Variable(np.array(2.0))
+        x2 = Variable(np.array(3.0))
+        y = mul(x1, x2)
+        self.assertTrue(np.allclose(y.data, np.array(6.0)))
+
+    def test_backward(self):
+        x1 = Variable(np.array(2.0))
+        x2 = Variable(np.array(3.0))
+        y = mul(x1, x2)
+        y.backward()
+        self.assertTrue(np.allclose(x1.grad, np.array(3.0)))
+        self.assertTrue(np.allclose(x2.grad, np.array(2.0)))
+
+    def test_operator_overload_with_scalar(self):
+        x = Variable(np.array(4.0))
+        y = x * 5
+        y.backward()
+        self.assertTrue(np.allclose(y.data, np.array(20.0)))
+        self.assertTrue(np.allclose(x.grad, np.array(5.0)))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/variable.py
+++ b/variable.py
@@ -85,15 +85,6 @@ class Variable:
             return value
         return Variable(np.array(value))
 
-    def __add__(self, other: Any) -> "Variable":
-        from add import add as add_func
-
-        other_var = self._ensure_variable(other)
-        return add_func(self, other_var)
-
-    def __radd__(self, other: Any) -> "Variable":
-        return self.__add__(other)
-
     def __pow__(self, power: Any) -> "Variable":
         from square import square as square_func
 


### PR DESCRIPTION
## 概要
- Mulクラスを追加し、前向き・後ろ向き計算で掛け算の微分を実装
- Variableに対する加算・乗算の演算子オーバーロードを追加し、スカラーにも対応
- 不要な逆順演算子とヘルパー関数を削除して実装を簡素化
- 加算と乗算の単体テストを更新し、演算子の振る舞いを検証

## テスト
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68eedea4d848832b8eb6d69468bec30c